### PR TITLE
fix build errors on gcc due to missing header

### DIFF
--- a/cbits/eigen-proxy.cpp
+++ b/cbits/eigen-proxy.cpp
@@ -3,6 +3,7 @@
 #include <Eigen/LeastSquares>
 #include <stdio.h>
 #include <sstream>
+#include <memory>
 
 static bool inited = eigen_initParallel();
 


### PR DESCRIPTION
I've got multiple errors about unknown std::auto_ptr etc. It's possible that <memory> used to be included indirectly but it is not in gcc 4.9.