### PR TITLE
adding `Flexible Contexts` to work with ghc710

### DIFF
--- a/Data/Eigen/SparseMatrix.hs
+++ b/Data/Eigen/SparseMatrix.hs
@@ -1,4 +1,7 @@
-{-# LANGUAGE GADTs, ScopedTypeVariables #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE FlexibleContexts #-}
+
 module Data.Eigen.SparseMatrix (
     -- * SparseMatrix type
     -- | SparseMatrix aliases follows Eigen naming convention


### PR DESCRIPTION
For everyone on ghc 7.10, this code base will fail to compile given 7.10's requirements for functions with inferred types. The fix is simply to add the `FlexibleContexts` language extension. Discussion on reddit of this change: https://www.reddit.com/r/haskell/comments/2zu5r9/on_adding_flexiblecontexts_to_please_ghc_710/

Observed error:

```
[5 of 6] Compiling Data.Eigen.SparseMatrix ( Data/Eigen/SparseMatrix.hs, dist/dist-sandbox-9ae015b6/build/Data/Eigen/SparseMatrix.o )

Data/Eigen/SparseMatrix.hs:234:9:
    Non type-variable argument in the constraint: I.Cast CInt t
    (Use FlexibleContexts to permit this)
    When checking that ‘f’ has the inferred type
      f :: forall t t1 t2 a.
           (I.Cast a t2, I.Cast CInt t, I.Cast CInt t1) =>
           I.CTriplet a -> (t, t1, t2)
    In the second argument of ‘($)’, namely
      ‘do { let s = nonZeros m;
            xs <- VSM.new s;
            withForeignPtr fp $ \ p -> VSM.unsafeWith xs $ \ q -> ...;
            let f (I.CTriplet row col val) = ...;
            .... }’
    In the expression:
      I.performIO
      $ do { let s = nonZeros m;
             xs <- VSM.new s;
             withForeignPtr fp $ \ p -> VSM.unsafeWith xs $ \ q -> ...;
             let f (I.CTriplet row col val) = ...;
             .... }
```